### PR TITLE
added settings menu: company name can now be changed

### DIFF
--- a/src/main/java/dataAccess/Cache.java
+++ b/src/main/java/dataAccess/Cache.java
@@ -12,6 +12,7 @@ import models.Certificate;
 import models.Employee;
 import models.Faq;
 import models.FollowingTraining;
+import models.Settings;
 import models.Teacher;
 import models.TrainingInfo;
 import models.TrainingSession;
@@ -138,6 +139,20 @@ public class Cache {
 					return TrainingBookAcces.get(key);
 				}
 			});
+	
+	public static LoadingCache<Integer, Settings> settingsCache = CacheBuilder.newBuilder().maximumSize(100)
+			.expireAfterAccess(30, TimeUnit.MINUTES).build(new CacheLoader<Integer, Settings>() {
+
+				@Override
+				public Settings load(Integer key) throws Exception {
+					return SettingsAccess.get();
+				}
+			});
+	
+	public static void loadSettings() throws IOException, URISyntaxException {
+		settingsCache.put(1, SettingsAccess.get());
+	}
+	
 	public static void loadAllTrainingBooks() throws IOException, URISyntaxException {
 		trainingBookCache.putAll(TrainingBookAcces.getAll());
 	}

--- a/src/main/java/dataAccess/Constants.java
+++ b/src/main/java/dataAccess/Constants.java
@@ -22,4 +22,5 @@ public class Constants {
 	public static final String USER_CERTIFICATES_SOURCE = DATA_SOURCE + "usercertificates/";
 	public static final String TOKEN_SOURCE= DATA_SOURCE +"token/";
 	public static final String STATISTICS_SOURCE= DATA_SOURCE +"statistics/";
+	public static final String SETTINGS_SOURCE = DATA_SOURCE +"companyinfoes/";
 }

--- a/src/main/java/dataAccess/SettingsAccess.java
+++ b/src/main/java/dataAccess/SettingsAccess.java
@@ -1,0 +1,20 @@
+package dataAccess;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import models.Settings;
+
+public class SettingsAccess extends RestRequest {
+	
+	public static Settings get() throws IOException, URISyntaxException {
+		String JSONAdr = getAllOrOne(new URI(Constants.SETTINGS_SOURCE + 1));
+		Settings settings = mapper.readValue(JSONAdr, Settings.class);
+		return settings;
+	}
+
+	public static void update(Settings settings) throws URISyntaxException, IOException {
+		putObject(settings, new URI(Constants.SETTINGS_SOURCE + 1));
+	}
+}

--- a/src/main/java/gui/AddBookPane.java
+++ b/src/main/java/gui/AddBookPane.java
@@ -1,20 +1,21 @@
 package gui;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import java.util.concurrent.ExecutionException;
 
 import javax.swing.BorderFactory;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JToggleButton;
+import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
-import java.awt.Font;
-import javax.swing.JTextField;
-import javax.swing.JButton;
+
+import dataAccess.Cache;
+import models.Settings;
 
 public class AddBookPane extends JPanel {
 
@@ -27,6 +28,9 @@ public class AddBookPane extends JPanel {
 	private JTextField txtBookTitle;
 	private JTextField txtBookAuthor;
 	private JButton btnAddBookToTrainingSession;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	/**
 	 * Create the panel.
@@ -38,6 +42,26 @@ public class AddBookPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  	try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -71,16 +95,6 @@ public class AddBookPane extends JPanel {
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
 	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
-	        
 	        lblBookTitle = new JLabel("Book title:");
 	        lblBookTitle.setFont(new Font("Tahoma", Font.BOLD, 14));
 	        lblBookTitle.setBounds(133, 182, 109, 34);
@@ -113,6 +127,7 @@ public class AddBookPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 	public String getBookTitleTrainingsession() {

--- a/src/main/java/gui/AddSurveyPane.java
+++ b/src/main/java/gui/AddSurveyPane.java
@@ -1,26 +1,24 @@
 package gui;
 
-import javax.swing.JPanel;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.RenderingHints.Key;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
@@ -32,20 +30,8 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
 import dataAccess.Cache;
-import dataAccess.SurveyQuestionAcces;
-import models.Address;
+import models.Settings;
 import models.SurveyQuestion;
-import models.Survey;
-import models.SurveyAnswer;
-import models.TrainingInfo;
-import models.TrainingSession;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.ActionEvent;
 
 public class AddSurveyPane extends JPanel {
 
@@ -66,6 +52,9 @@ public class AddSurveyPane extends JPanel {
 	private JButton btnBackToNewTrainingsession;
 	private ListSelectionModel selectedRowQuestionsSurvey;
 	private ListSelectionModel selectedRowHistoryQuestions;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	public DefaultTableModel gettableQuestionsSurveyModel() {
 		 return this.tableQuestionsSurveyModel;
@@ -93,6 +82,26 @@ public class AddSurveyPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  	try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -125,16 +134,6 @@ public class AddSurveyPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 	        
 	        Object [] columnHeaderQuestionsSurvey = {"Questions for the survey"};
 	        List<String[]> data1 = new ArrayList<String[]>();	       
@@ -309,6 +308,7 @@ public class AddSurveyPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 	public String getAddQuestion() {

--- a/src/main/java/gui/AddTeacherPane.java
+++ b/src/main/java/gui/AddTeacherPane.java
@@ -1,35 +1,21 @@
 package gui;
 
-import javax.swing.JPanel;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Font;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.util.ArrayList;
-import java.util.List;
+import java.awt.event.ActionListener;
+import java.util.concurrent.ExecutionException;
 
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
 import javax.swing.JLabel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
+import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.JToggleButton;
-import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumnModel;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.ActionEvent;
+
+import dataAccess.Cache;
+import models.Settings;
 
 public class AddTeacherPane extends JPanel {
 
@@ -42,6 +28,9 @@ public class AddTeacherPane extends JPanel {
 	private JTextField txtTeacherEmail;
 	private JTextField txtTeacherPhoneNumber;
 	private JButton btnSubmitAddTeacher;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	/**
 	 * Create the panel.
@@ -52,6 +41,26 @@ public class AddTeacherPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  	try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -84,16 +93,6 @@ public class AddTeacherPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 	        
 	        JLabel lblTeacherFirstName = new JLabel("First name:");
 	        lblTeacherFirstName.setFont(new Font("Tahoma", Font.BOLD, 14));
@@ -147,6 +146,7 @@ public class AddTeacherPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	public String getTeacherFirstnameSearch() {
         return txtTeacherFirstName.getText();

--- a/src/main/java/gui/ExtraInfoEmployee.java
+++ b/src/main/java/gui/ExtraInfoEmployee.java
@@ -1,20 +1,14 @@
 package gui;
 
-import javax.swing.JPanel;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-//import java.awt.Image;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,52 +16,43 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import dataAccess.Cache;
-import dataAccess.CertificateAccess;
-import dataAccess.EmployeeAccess;
-import dataAccess.TrainingInfoAccess;
-import dataAccess.TrainingSessionAccess;
-import models.Certificate;
-import models.Employee;
-import models.TrainingInfo;
-import models.TrainingSession;
-import models.UserCertificate;
-
-import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.ActionEvent;
-import javax.swing.JTextArea;
-import javax.swing.border.LineBorder;
-
 import com.itextpdf.io.image.ImageData;
 import com.itextpdf.io.image.ImageDataFactory;
 import com.itextpdf.kernel.pdf.PdfDocument;
 import com.itextpdf.kernel.pdf.PdfWriter;
-import com.itextpdf.kernel.pdf.canvas.draw.DottedLine;
 import com.itextpdf.layout.Document;
-import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.element.Image;
 //import com.itextpdf.layout.element.List;
+import com.itextpdf.layout.element.Paragraph;
+
+import dataAccess.Cache;
+import dataAccess.CertificateAccess;
+import dataAccess.EmployeeAccess;
+import dataAccess.TrainingInfoAccess;
+import models.Certificate;
+import models.Employee;
+import models.Settings;
+import models.TrainingInfo;
+import models.UserCertificate;
 
 
 public class ExtraInfoEmployee extends JPanel {
@@ -91,6 +76,9 @@ public class ExtraInfoEmployee extends JPanel {
 	private JLabel lblLastName;
 	private JLabel lblShowImageIcon;
 	private DefaultTableModel tableModel;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 
 	/**
 	 * Create the panel.
@@ -112,6 +100,26 @@ public class ExtraInfoEmployee extends JPanel {
 
 
 		Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		
+		try {
+			settings = Cache.settingsCache.get(1);
+		} catch (ExecutionException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+        
+        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+        companyName.setBounds(10, 0, 110, 75);
+        companyName.setOpaque(true);
+        add(companyName);
+	  
+	  	jtbSettings = new JButton("Settings");
+	  	jtbSettings.setBackground(Color.WHITE);
+	  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+        jtbSettings.setOpaque(true);
+        jtbSettings.setActionCommand("SettingsMenu");
+        jtbSettings.setBounds(1190, 12, 70, 50);
+        add(jtbSettings);
 
 
 		btnTraining = new JButton("Training");
@@ -207,18 +215,6 @@ public class ExtraInfoEmployee extends JPanel {
 		jtbTrainingRequests.setActionCommand("TrainingRequestsMenu");
 		jtbTrainingRequests.setBounds(979, 0, 211, 75);
 		add(jtbTrainingRequests); */
-
-		JLabel lblNewLabel = new JLabel("logo");
-		lblNewLabel.setBounds(0, 0, 133, 75);
-		lblNewLabel.setOpaque(true);
-		add(lblNewLabel);
-
-		JLabel lblNewLabel_1 = new JLabel("Profiel");
-		lblNewLabel_1.setBounds(1190, 0, 75, 75);
-		lblNewLabel_1.setOpaque(true);
-		add(lblNewLabel_1);
-
-
 
 		JLabel employeeLabel = new JLabel("Employee search by ID: ");
 		employeeLabel.setFont(new Font("Tahoma", Font.BOLD, 14));
@@ -644,5 +640,6 @@ public class ExtraInfoEmployee extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingSession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
 	}
 }

--- a/src/main/java/gui/MainFrame.java
+++ b/src/main/java/gui/MainFrame.java
@@ -20,6 +20,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
 import com.google.api.client.json.JsonFactory;
@@ -27,6 +28,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 
 import dataAccess.Cache;
 import dataAccess.GoogleBooksAPI;
+import dataAccess.SettingsAccess;
 import dataAccess.SurveyQuestionAcces;
 import dataAccess.TrainingInfoAccess;
 //import gui.EmployeePane;
@@ -35,6 +37,7 @@ import models.Book;
 import models.TrainingInfo;
 import models.TrainingSession;
 import models.Login;
+import models.Settings;
 import models.Survey;
 import models.SurveyQuestion;
 import models.Teacher;
@@ -54,6 +57,26 @@ public class MainFrame extends JFrame {
 	private Book book ;
 	private TrainingBooks trainingBooks;
 	private TrainingSession session;
+	private Settings settings;
+	
+	private LoginPane newLoginPane;
+	private TrainingPane trainingPanel;
+	private TrainingSessionPane trainingSessionPanel;
+	private NewTrainingSessionPane newNewTrainingSessionPanel;
+	private StatisticsPane statisticsPanel;
+	private ExtraInfoEmployee employeePanel;
+	private TrainingSessionBookPane newTrainingSessionBookPane;
+	private TrainingSessionPoeplePane newTrainingSessionPoeplePane;
+	private TrainingSessionInfoPane newTrainingSessionInfoPane;
+	private SelectTrainingPane newSelectTrainingPane;
+	private NewTrianingPane newNewTrianingPane;
+	private AddTeacherPane addTeacherPanel;
+	private AddBookPane addBookPanel;
+	private AddSurveyPane addSurveyPanel;
+	private StatisticsCertificatesEmployeePane statisticsCertificatesEmployeePanel;
+	private StatisticsFollowedTrainingPane statisticsFollowedTrainingPanel;
+	private StatisticsTrainingParticipationPane statisticsTrainingParticipationPanel;
+	private TrainingSessionMapPane newTrainingSessionMapPane;
 			
 	
 
@@ -89,27 +112,41 @@ public class MainFrame extends JFrame {
         final CardLayout layout = new CardLayout();
         getContentPane().setLayout(layout);
         
+        //get settings from dataservice and save them in chache
+        try {
+			this.settings = SettingsAccess.get();
+			Cache.settingsCache.put(1, settings);//opslaan in cache
+		} catch (IOException e2) {
+			// TODO Auto-generated catch block
+			e2.printStackTrace();
+			this.settings = new Settings(1, "company name");
+		} catch (URISyntaxException e2) {
+			// TODO Auto-generated catch block
+			e2.printStackTrace();
+			this.settings = new Settings(1, "company name");
+		}
+        
         Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
         this.setLocation(dim.width/2-this.getSize().width/2, dim.height/2-this.getSize().height/2);
 		
-        LoginPane newLoginPane =  new LoginPane();
-        TrainingPane trainingPanel = new TrainingPane();
-        TrainingSessionPane trainingSessionPanel = new TrainingSessionPane();
-        NewTrainingSessionPane newNewTrainingSessionPanel = new NewTrainingSessionPane();
-        StatisticsPane statisticsPanel = new StatisticsPane();    
-        ExtraInfoEmployee employeePanel = new ExtraInfoEmployee();
-        TrainingSessionBookPane newTrainingSessionBookPane = new TrainingSessionBookPane();
-        TrainingSessionPoeplePane newTrainingSessionPoeplePane = new TrainingSessionPoeplePane();
-        TrainingSessionInfoPane newTrainingSessionInfoPane = new TrainingSessionInfoPane();
-        SelectTrainingPane newSelectTrainingPane = new SelectTrainingPane();
-        NewTrianingPane newNewTrianingPane = new NewTrianingPane();
-        AddTeacherPane addTeacherPanel = new AddTeacherPane();
-        AddBookPane addBookPanel = new AddBookPane(); 
-        AddSurveyPane addSurveyPanel = new AddSurveyPane();
-        StatisticsCertificatesEmployeePane statisticsCertificatesEmployeePanel = new StatisticsCertificatesEmployeePane();
-        StatisticsFollowedTrainingPane statisticsFollowedTrainingPanel = new StatisticsFollowedTrainingPane();
-        StatisticsTrainingParticipationPane statisticsTrainingParticipationPanel = new StatisticsTrainingParticipationPane();
-        TrainingSessionMapPane newTrainingSessionMapPane = new TrainingSessionMapPane();
+        this.newLoginPane =  new LoginPane();
+        this.trainingPanel = new TrainingPane();
+        this.trainingSessionPanel = new TrainingSessionPane();
+        this.newNewTrainingSessionPanel = new NewTrainingSessionPane();
+        this.statisticsPanel = new StatisticsPane();    
+        this.employeePanel = new ExtraInfoEmployee();
+        this.newTrainingSessionBookPane = new TrainingSessionBookPane();
+        this.newTrainingSessionPoeplePane = new TrainingSessionPoeplePane();
+        this.newTrainingSessionInfoPane = new TrainingSessionInfoPane();
+        this.newSelectTrainingPane = new SelectTrainingPane();
+        this.newNewTrianingPane = new NewTrianingPane();
+        this.addTeacherPanel = new AddTeacherPane();
+        this.addBookPanel = new AddBookPane(); 
+        this.addSurveyPanel = new AddSurveyPane();
+        this.statisticsCertificatesEmployeePanel = new StatisticsCertificatesEmployeePane();
+        this.statisticsFollowedTrainingPanel = new StatisticsFollowedTrainingPane();
+        this.statisticsTrainingParticipationPanel = new StatisticsTrainingParticipationPane();
+        this.newTrainingSessionMapPane = new TrainingSessionMapPane();
 
 
         
@@ -157,7 +194,9 @@ public class MainFrame extends JFrame {
                 } else if ("goToTrainingSessionInfo".equals(command)) {
                     //show trainingsessioninfopane
                     layout.show(getContentPane(), "TrainingSessionInfoPane");
-                }
+                } else if ("SettingsMenu".equals(command)) {
+            			settingsDialog();
+                } 
                 
             }
         });
@@ -224,7 +263,9 @@ public class MainFrame extends JFrame {
                 }else if ("goToAddTraining".equals(command)) {
                 	//show addTrainingMenu
                 	layout.show(getContentPane(), "NewTrianingPane");
-                }
+                } else if ("SettingsMenu".equals(command)) {
+            			settingsDialog();
+                } 
                 	
             }
         });
@@ -262,7 +303,9 @@ public class MainFrame extends JFrame {
                         
                         newTrainingSessionBookPane.setBtnCancelTrainingSession(trainingSessionPanel.getTrainingSessionID());
                         
-                    }
+                    } else if ("SettingsMenu".equals(command)) {
+            			settingsDialog();
+                    } 
                     
                 }
             });
@@ -374,7 +417,9 @@ public class MainFrame extends JFrame {
                     	
                     	// layout.show van je survey toevoegen nog maken
                     	layout.show(getContentPane(), "addSurveyPanel");
-                    }                   
+                    }  else if ("SettingsMenu".equals(command)) {
+            			settingsDialog();
+                    }                     
                 }
             });
         	
@@ -404,6 +449,8 @@ public class MainFrame extends JFrame {
                     } else if ("goToStatisticsCertificatesEmployee".equals(command)) {
                     	//show StatisticsCertPane
                     	layout.show(getContentPane(), "statisticsCertificatesEmployeePanel");
+                    } else if ("SettingsMenu".equals(command)) {
+            			settingsDialog();
                     } 
                 }
             });
@@ -448,7 +495,9 @@ public class MainFrame extends JFrame {
                             //show TrainingSessoinMapsPane
                             layout.show(getContentPane(), "TrainingSessionMapPane");
                             newTrainingSessionMapPane.setBtnCancelTrainingSession(trainingSessionPanel.getTrainingSessionID());
-                        }
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        } 
                     }
                 });
         		
@@ -493,7 +542,9 @@ public class MainFrame extends JFrame {
                             //show TrainingSessoinMapsPane
                             layout.show(getContentPane(), "TrainingSessionMapPane");
                             newTrainingSessionMapPane.setBtnCancelTrainingSession(trainingSessionPanel.getTrainingSessionID());
-                        }
+                        }  else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        } 
                         
                     }
                 });
@@ -538,7 +589,9 @@ public class MainFrame extends JFrame {
                             //show TrainingSessoinMapsPane
                             layout.show(getContentPane(), "TrainingSessionMapPane");
                             newTrainingSessionMapPane.setBtnCancelTrainingSession(trainingSessionPanel.getTrainingSessionID());
-                        }
+                        }  else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        } 
                         
                     }
                 });
@@ -584,7 +637,9 @@ public class MainFrame extends JFrame {
                             //show TrainingSessoinMapsPane
                             layout.show(getContentPane(), "TrainingSessionMapPane");
                             newTrainingSessionMapPane.setBtnCancelTrainingSession(trainingSessionPanel.getTrainingSessionID());
-                        }
+                        }  else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        } 
                     }
                 });
         		
@@ -710,6 +765,8 @@ public class MainFrame extends JFrame {
                         	
                         	layout.show(getContentPane(), "NewTrainingSessionPane");
                         	}
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
                         } 
                     }
                 });
@@ -781,7 +838,9 @@ public class MainFrame extends JFrame {
                 		    }
                 		    
                         	layout.show(getContentPane(), "NewTrainingSessionPane");
-                        } 
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        }  
                     }
                 });
         		
@@ -892,6 +951,8 @@ public class MainFrame extends JFrame {
 
                         	//Confirm the survey and go back to newtrainingsessionpane
                         	layout.show(getContentPane(), "NewTrainingSessionPane");
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
                         }
                     }
                 });
@@ -919,7 +980,9 @@ public class MainFrame extends JFrame {
                         } else if ("backCertToStatistics".equals(command)) {
                         	// Terug naar statistiekenpanel
                         	layout.show(getContentPane(), "statisticsPanel");
-                        } 
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        }
                         
                     }
                 });
@@ -947,7 +1010,9 @@ public class MainFrame extends JFrame {
                         } else if ("backFollowedToStatistics".equals(command)) {
                         	// Terug naar statistiekenpanel
                         	layout.show(getContentPane(), "statisticsPanel");
-                        } 
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        }
                         
                     }
                 });
@@ -975,7 +1040,9 @@ public class MainFrame extends JFrame {
                         } else if ("backPartToStatistics".equals(command)) {
                         	// Terug naar statistiekenpanel
                         	layout.show(getContentPane(), "statisticsPanel");
-                        } 
+                        } else if ("SettingsMenu".equals(command)) {
+                			settingsDialog();
+                        }
                     }
                 });
         		
@@ -1009,6 +1076,50 @@ public class MainFrame extends JFrame {
 	public void setSession(TrainingSession session) {
 		this.session = session;
 	}
-
 	
+	public void settingsDialog() {
+		// show settings dialog
+		String s = (String)JOptionPane.showInputDialog(
+                null,
+                "Company name",
+                "Customized Dialog",
+                JOptionPane.PLAIN_MESSAGE,
+                null,
+                null,
+                settings.getCompanyName());
+
+	    if (s != null) {
+	    		//update settings
+	        settings.setCompanyName(s);
+	        //update cache
+	        Cache.settingsCache.put(1, settings);
+	        //put new settings object to server
+	        try {
+				SettingsAccess.update(settings);
+			} catch (URISyntaxException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			} catch (IOException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+	    }
+	    //update all panes(oh lord)
+        this.trainingPanel.companyName.setText(settings.getCompanyName());
+        this.trainingSessionPanel.companyName.setText(settings.getCompanyName());
+        this.newNewTrainingSessionPanel.companyName.setText(settings.getCompanyName());
+        this.statisticsPanel.companyName.setText(settings.getCompanyName());
+        this.employeePanel.companyName.setText(settings.getCompanyName());
+        this.newNewTrianingPane.companyName.setText(settings.getCompanyName());
+        this.newTrainingSessionBookPane.companyName.setText(settings.getCompanyName());
+        this.newTrainingSessionPoeplePane.companyName.setText(settings.getCompanyName());
+        this.newTrainingSessionInfoPane.companyName.setText(settings.getCompanyName());
+        this.addTeacherPanel.companyName.setText(settings.getCompanyName());
+        this.addBookPanel.companyName.setText(settings.getCompanyName());
+        this.addSurveyPanel.companyName.setText(settings.getCompanyName());
+        this.statisticsCertificatesEmployeePanel.companyName.setText(settings.getCompanyName());
+        this.statisticsFollowedTrainingPanel.companyName.setText(settings.getCompanyName());
+        this.statisticsTrainingParticipationPanel.companyName.setText(settings.getCompanyName());
+        this.newTrainingSessionMapPane.companyName.setText(settings.getCompanyName());
+	}
 }

--- a/src/main/java/gui/NewTrainingSessionPane.java
+++ b/src/main/java/gui/NewTrainingSessionPane.java
@@ -1,38 +1,26 @@
 package gui;
 
-import javax.swing.JPanel;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Font;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.sql.Time;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import javax.swing.JLabel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingConstants;
-import javax.swing.border.Border;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumnModel;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
-import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.sql.Time;
+import java.util.concurrent.ExecutionException;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+
+import dataAccess.Cache;
+import models.Settings;
 
 public class NewTrainingSessionPane extends JPanel {
 
@@ -56,6 +44,9 @@ public class NewTrainingSessionPane extends JPanel {
 	private JButton btnAddTeacher;
 	private JButton btnAddBook;
 	private JButton btnaddSurvey;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	/**
 	 * Create the panel.
@@ -66,6 +57,26 @@ public class NewTrainingSessionPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -98,16 +109,6 @@ public class NewTrainingSessionPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 	       
 		
 		btnBack = new JButton("Back");
@@ -371,6 +372,7 @@ public class NewTrainingSessionPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	public String getTitle() {
         return txtTitle.getText();

--- a/src/main/java/gui/NewTrianingPane.java
+++ b/src/main/java/gui/NewTrianingPane.java
@@ -4,8 +4,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import java.util.concurrent.ExecutionException;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -14,12 +13,12 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
-import models.TrainingInfo;
+import dataAccess.Cache;
+import models.Settings;
 
 public class NewTrianingPane extends JPanel {
 	
@@ -39,6 +38,9 @@ public class NewTrianingPane extends JPanel {
 	private JScrollPane sclDescription;
 	private JScrollPane sclDescriptionExam;
 	private JScrollPane sclDescriptionPayement;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	/**
 	 * Create the panel.
@@ -49,6 +51,26 @@ public class NewTrianingPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training");
 		  btnTraining.addActionListener(new ActionListener() {
@@ -133,16 +155,6 @@ public class NewTrianingPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 		
 		btnBack = new JButton("Back");
 		btnBack.addActionListener(new ActionListener() {
@@ -266,6 +278,7 @@ public class NewTrianingPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	public String getTitle() {
 		

--- a/src/main/java/gui/SelectTrainingPane.java
+++ b/src/main/java/gui/SelectTrainingPane.java
@@ -3,8 +3,6 @@ package gui;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.Panel;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,14 +23,8 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableModel;
-
-import org.omg.CORBA.PUBLIC_MEMBER;
-
-import com.itextpdf.kernel.pdf.filters.IFilterHandler;
 
 import models.TrainingInfo;
-import models.TrainingSession;
 
 public class SelectTrainingPane extends JPanel {
 	

--- a/src/main/java/gui/StatisticsCertificatesEmployeePane.java
+++ b/src/main/java/gui/StatisticsCertificatesEmployeePane.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -40,12 +41,12 @@ import com.itextpdf.layout.Document;
 import com.itextpdf.layout.element.Image;
 import com.itextpdf.layout.element.Paragraph;
 
+import dataAccess.Cache;
 import dataAccess.CertificateAccess;
 import dataAccess.EmployeeAccess;
-import dataAccess.TrainingInfoAccess;
 import models.Certificate;
 import models.Employee;
-import models.TrainingInfo;
+import models.Settings;
 
 public class StatisticsCertificatesEmployeePane extends JPanel {
 
@@ -65,6 +66,9 @@ public class StatisticsCertificatesEmployeePane extends JPanel {
 	private JLabel lblNameFixed;
 	private JLabel lblName;
 	private JLabel lblFirstName;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 
 
 
@@ -83,6 +87,26 @@ public class StatisticsCertificatesEmployeePane extends JPanel {
 
 
 		Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+	  	try {
+			settings = Cache.settingsCache.get(1);
+		} catch (ExecutionException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+        
+        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+        companyName.setBounds(10, 0, 110, 75);
+        companyName.setOpaque(true);
+        add(companyName);
+	  
+	  	jtbSettings = new JButton("Settings");
+	  	jtbSettings.setBackground(Color.WHITE);
+	  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+        jtbSettings.setOpaque(true);
+        jtbSettings.setActionCommand("SettingsMenu");
+        jtbSettings.setBounds(1190, 12, 70, 50);
+        add(jtbSettings);
 
 		btnTraining = new JButton("Training");
 		btnTraining.addActionListener(new ActionListener() {
@@ -151,16 +175,6 @@ public class StatisticsCertificatesEmployeePane extends JPanel {
 		btnStatistics.setActionCommand("StatisticsMenu");
 		btnStatistics.setBounds(916, 0, 264, 75);
 		add(btnStatistics);
-
-		JLabel lblNewLabel = new JLabel("logo");
-		lblNewLabel.setBounds(0, 0, 133, 75);
-		lblNewLabel.setOpaque(true);
-		add(lblNewLabel);
-
-		JLabel lblNewLabel_1 = new JLabel("Profiel");
-		lblNewLabel_1.setBounds(1190, 0, 75, 75);
-		lblNewLabel_1.setOpaque(true);
-		add(lblNewLabel_1);
 
 		JLabel lblUitlegCert = new JLabel("Write employeeID to get information");
 		lblUitlegCert.setFont(new Font("Tahoma", Font.BOLD, 14));
@@ -436,6 +450,7 @@ public class StatisticsCertificatesEmployeePane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
 	}
 
 	public String getEmployeeIDCertTraining() {

--- a/src/main/java/gui/StatisticsFollowedTrainingPane.java
+++ b/src/main/java/gui/StatisticsFollowedTrainingPane.java
@@ -2,31 +2,8 @@ package gui;
 
 import java.awt.Color;
 import java.awt.Component;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.border.Border;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumnModel;
-
-import dataAccess.AddressAccess;
-import dataAccess.EmployeeAccess;
-import dataAccess.TrainingInfoAccess;
-import dataAccess.TrainingSessionAccess;
-import models.Employee;
-import models.TrainingInfo;
-import models.TrainingSession;
-
 import java.awt.Font;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -37,11 +14,34 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
-import javax.swing.JTextArea;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
-import java.awt.event.ActionEvent;
+import javax.swing.SwingConstants;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumnModel;
+
+import dataAccess.AddressAccess;
+import dataAccess.Cache;
+import dataAccess.EmployeeAccess;
+import dataAccess.TrainingInfoAccess;
+import dataAccess.TrainingSessionAccess;
+import models.Employee;
+import models.Settings;
+import models.TrainingInfo;
+import models.TrainingSession;
 
 public class StatisticsFollowedTrainingPane extends JPanel {
 
@@ -66,6 +66,9 @@ public class StatisticsFollowedTrainingPane extends JPanel {
 	private JLabel lblTotalOfPriceFixed;
 	private JLabel lblTotalOfDays;
 	private JLabel lblTotalOfPrice;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 
 
 	/**
@@ -81,6 +84,26 @@ public class StatisticsFollowedTrainingPane extends JPanel {
 
 
 		Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+	  	try {
+			settings = Cache.settingsCache.get(1);
+		} catch (ExecutionException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+        
+        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+        companyName.setBounds(10, 0, 110, 75);
+        companyName.setOpaque(true);
+        add(companyName);
+	  
+	  	jtbSettings = new JButton("Settings");
+	  	jtbSettings.setBackground(Color.WHITE);
+	  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+        jtbSettings.setOpaque(true);
+        jtbSettings.setActionCommand("SettingsMenu");
+        jtbSettings.setBounds(1190, 12, 70, 50);
+        add(jtbSettings);
 
 		btnTraining = new JButton("Training");
 		btnTraining.addActionListener(new ActionListener() {
@@ -187,16 +210,6 @@ public class StatisticsFollowedTrainingPane extends JPanel {
 		jtbTrainingRequests.setActionCommand("TrainingRequestsMenu");
 		jtbTrainingRequests.setBounds(979, 0, 211, 75);
 		add(jtbTrainingRequests); */
-
-		JLabel lblNewLabel = new JLabel("logo");
-		lblNewLabel.setBounds(0, 0, 133, 75);
-		lblNewLabel.setOpaque(true);
-		add(lblNewLabel);
-
-		JLabel lblNewLabel_1 = new JLabel("Profiel");
-		lblNewLabel_1.setBounds(1190, 0, 75, 75);
-		lblNewLabel_1.setOpaque(true);
-		add(lblNewLabel_1);
 
 		JLabel lblUitleg = new JLabel("Write employeeID to get information");
 		lblUitleg.setFont(new Font("Tahoma", Font.BOLD, 14));
@@ -447,6 +460,7 @@ public class StatisticsFollowedTrainingPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
 	}
 
 }

--- a/src/main/java/gui/StatisticsPane.java
+++ b/src/main/java/gui/StatisticsPane.java
@@ -1,20 +1,20 @@
 package gui;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import java.util.concurrent.ExecutionException;
 
 import javax.swing.BorderFactory;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JToggleButton;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
-import java.awt.Font;
-import javax.swing.JButton;
+import dataAccess.Cache;
+import models.Settings;
 
 public class StatisticsPane extends JPanel {
 
@@ -26,6 +26,9 @@ public class StatisticsPane extends JPanel {
 	private JButton btnParticipationTrainingsEmployeeStatistics;
 	private JButton btnParticipationMaxEmployeeStatistics;
 	private JButton btnCertEmployeeStatistics;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	/**
 	 * Create the panel.
@@ -36,6 +39,26 @@ public class StatisticsPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -68,16 +91,6 @@ public class StatisticsPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
         
         lblNewLabel_2 = new JLabel("Choose an option to consult statistics");
         lblNewLabel_2.setFont(new Font("Tahoma", Font.BOLD, 14));
@@ -109,5 +122,6 @@ public class StatisticsPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 }

--- a/src/main/java/gui/StatisticsTrainingParticipationPane.java
+++ b/src/main/java/gui/StatisticsTrainingParticipationPane.java
@@ -5,6 +5,11 @@ import java.awt.Component;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -23,25 +28,10 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import java.awt.Font;
-import java.awt.event.ActionListener;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
-
-import dataAccess.EmployeeAccess;
+import dataAccess.Cache;
 import dataAccess.StatisticsAccess;
-import dataAccess.TrainingInfoAccess;
-import dataAccess.TrainingSessionAccess;
-import dataAccess.UserAccess;
 import models.EmpHighTrainingCount;
-import models.Employee;
-import models.TrainingInfo;
-import models.TrainingSession;
+import models.Settings;
 
 public class StatisticsTrainingParticipationPane extends JPanel {
 
@@ -60,6 +50,9 @@ public class StatisticsTrainingParticipationPane extends JPanel {
 	private JButton btnParticipationBackStatistics;
 	private JLabel lblFirstName;
 	private JLabel lblLastname;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	
 	/**
@@ -74,6 +67,26 @@ public class StatisticsTrainingParticipationPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  	try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.addActionListener(new ActionListener() {
@@ -142,16 +155,6 @@ public class StatisticsTrainingParticipationPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 	        
 	        JLabel lblUitlegPart = new JLabel("Write year to retrieve data");
 	        lblUitlegPart.setFont(new Font("Tahoma", Font.BOLD, 14));
@@ -323,6 +326,7 @@ public class StatisticsTrainingParticipationPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 }			

--- a/src/main/java/gui/TrainingPane.java
+++ b/src/main/java/gui/TrainingPane.java
@@ -1,29 +1,24 @@
 package gui;
 
-import javax.swing.JPanel;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
+import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
@@ -33,28 +28,13 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableModel;
 
-
-import com.google.api.client.util.Key;
-import com.google.common.cache.Cache;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.ActionEvent;
-import models.TrainingInfo;
-import models.TrainingSession;
-import dataAccess.TrainingInfoAccess;
-import dataAccess.TrainingSessionAccess;
+import dataAccess.Cache;
 
 import models.Address;
+import models.Settings;
 import models.TrainingInfo;
 import models.TrainingSession;
-import dataAccess.TrainingInfoAccess;
-import dataAccess.TrainingSessionAccess;
 
 public class TrainingPane extends JPanel {
 	private String fullEmployee;
@@ -68,6 +48,9 @@ public class TrainingPane extends JPanel {
 	private JLabel lblCityTraining;
 	private JLabel lblNewLabel_2;
 	private int tabelID;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	
 	/**
@@ -108,6 +91,26 @@ public class TrainingPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -140,16 +143,6 @@ public class TrainingPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 	        
 	        btnSelectTraining = new JButton("Select Training");
 	        btnSelectTraining.setActionCommand("goToSelectTraining");
@@ -251,6 +244,7 @@ public class TrainingPane extends JPanel {
 		btnStatistics.addActionListener(listener);
 		btnEmployees.addActionListener(listener);
 		btnTrainingsession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	public void setTabelID(int tabelid) {
 		this.tabelID=tabelid;

--- a/src/main/java/gui/TrainingSessionBookPane.java
+++ b/src/main/java/gui/TrainingSessionBookPane.java
@@ -3,17 +3,13 @@ package gui;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.SystemColor;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
@@ -24,7 +20,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
@@ -34,14 +29,11 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
- 
+
 import dataAccess.BookAccess;
 import dataAccess.Cache;
-import dataAccess.EmployeeAccess;
-import models.Address;
 import models.Book;
-import models.Employee;
-import models.TrainingInfo;
+import models.Settings;
 import models.TrainingSession;
 
 public class TrainingSessionBookPane extends JPanel {
@@ -63,6 +55,9 @@ public class TrainingSessionBookPane extends JPanel {
 	private JButton btnTrainingsession;
 	private JButton btnMaps;
 	private MainFrame mainFrame;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 
 	/**
 	 * Create the panel.
@@ -84,6 +79,26 @@ public class TrainingSessionBookPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.addActionListener(new ActionListener() {
@@ -148,16 +163,6 @@ public class TrainingSessionBookPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 		
 		btnBack = new JButton("Back");
 		btnBack.addActionListener(new ActionListener() {
@@ -301,6 +306,7 @@ public class TrainingSessionBookPane extends JPanel {
 		btnEnlistedPeople.addActionListener(listener);
 		btnBooks.addActionListener(listener);
 		btnMaps.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 	public String getSearch() {

--- a/src/main/java/gui/TrainingSessionInfoPane.java
+++ b/src/main/java/gui/TrainingSessionInfoPane.java
@@ -2,10 +2,7 @@ package gui;
 
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.SystemColor;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -17,13 +14,12 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
-import javax.swing.JToggleButton;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
 import dataAccess.Cache;
-import models.Employee;
+import models.Settings;
 import models.TrainingInfo;
 import models.TrainingSession;
  
@@ -43,6 +39,9 @@ public class TrainingSessionInfoPane extends JPanel {
 	private JButton btnStatistics;
 	private JButton btnTrainingsession;
 	private JButton btnMaps;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 	
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -64,6 +63,26 @@ public class TrainingSessionInfoPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -96,16 +115,6 @@ public class TrainingSessionInfoPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 		
 		btnBack = new JButton("Back");
 		btnBack.setBounds(30, 100, 110, 50);
@@ -201,6 +210,7 @@ public class TrainingSessionInfoPane extends JPanel {
 		btnBack.addActionListener(listener);
 		btnCancelTrainingSession.addActionListener(listener);
 		btnMaps.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 	public String getGeneralInfo() {

--- a/src/main/java/gui/TrainingSessionMapPane.java
+++ b/src/main/java/gui/TrainingSessionMapPane.java
@@ -15,21 +15,20 @@ import java.util.concurrent.ExecutionException;
 
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
-import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JTextArea;
+import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
 import dataAccess.Cache;
 import models.Address;
+import models.Settings;
 import models.TrainingInfo;
 import models.TrainingSession;
-import javax.swing.JTextField;
 
 
 public class TrainingSessionMapPane extends JPanel {
@@ -75,6 +74,9 @@ public class TrainingSessionMapPane extends JPanel {
 	private JLabel lblPremise;
 	private JLabel lbl6;
 	private JLabel lblCountry;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 
 	/**
@@ -85,6 +87,26 @@ public class TrainingSessionMapPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  	try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -117,16 +139,6 @@ public class TrainingSessionMapPane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 		
 		btnBack = new JButton("<-  Back");
 		btnBack.setBounds(30, 100, 110, 50);
@@ -246,6 +258,7 @@ public class TrainingSessionMapPane extends JPanel {
 		btnBack.addActionListener(listener);
 		btnCancelTrainingSession.addActionListener(listener);
 		btnMaps.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	public void setImage(int id) {
 		String address = null;

--- a/src/main/java/gui/TrainingSessionPane.java
+++ b/src/main/java/gui/TrainingSessionPane.java
@@ -2,28 +2,21 @@ package gui;
 
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.EventQueue;
 import java.awt.Font;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.io.IOException;
-import java.net.URISyntaxException;
+import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
@@ -34,16 +27,11 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import dataAccess.TrainingInfoAccess;
-import dataAccess.TrainingSessionAccess;
+import dataAccess.Cache;
 import models.Address;
+import models.Settings;
 import models.TrainingInfo;
 import models.TrainingSession;
-
-import java.awt.event.ActionListener;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.ActionEvent;
 
 public class TrainingSessionPane extends JPanel {
 
@@ -62,6 +50,9 @@ public class TrainingSessionPane extends JPanel {
 	private String trainingSessionID;
 	private String addressID;
 	private String trainingID;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 
 	
@@ -85,6 +76,26 @@ public class TrainingSessionPane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 	        jtbTraining = new JButton("Training"); 
 	        jtbTraining.setBackground(Color.WHITE);
@@ -117,11 +128,6 @@ public class TrainingSessionPane extends JPanel {
 	        jtbStatistics.setActionCommand("StatisticsMenu");
 	        jtbStatistics.setBounds(912, 0, 264, 75);
 	        add(jtbStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
 		
 		Object [] columnHeadersSession = {"Training ID", "Training name","City","Date","Hour"};
 		DefaultTableModel modelSession = new DefaultTableModel();
@@ -207,6 +213,7 @@ public class TrainingSessionPane extends JPanel {
 		jtbStatistics.addActionListener(listener);
 		jtbEmployees.addActionListener(listener);
 		jtbTrainingSession.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 	

--- a/src/main/java/gui/TrainingSessionPoeplePane.java
+++ b/src/main/java/gui/TrainingSessionPoeplePane.java
@@ -3,32 +3,21 @@ package gui;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.SystemColor;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
-import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
@@ -39,12 +28,10 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import com.fasterxml.jackson.databind.util.TypeKey;
-
 import dataAccess.Cache;
 import dataAccess.EmployeeAccess;
-import models.Address;
 import models.Employee;
+import models.Settings;
 import models.TrainingInfo;
 import models.TrainingSession;
 
@@ -62,6 +49,9 @@ public class TrainingSessionPoeplePane extends JPanel {
 	private JButton btnStatistics;
 	private JButton btnTrainingsession;
 	private JButton btnMaps;
+	private JButton jtbSettings;
+	private Settings settings;
+	public JLabel companyName;
 	
 
 	public TrainingSessionPoeplePane() {
@@ -85,6 +75,26 @@ public class TrainingSessionPoeplePane extends JPanel {
 		setLayout(null);
 		
 		  Border border = BorderFactory.createLineBorder(Color.BLACK, 1);
+		  
+		  try {
+				settings = Cache.settingsCache.get(1);
+			} catch (ExecutionException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+	        
+	        companyName = new JLabel(settings.getCompanyName()); //uit cache halen f
+	        companyName.setBounds(10, 0, 110, 75);
+	        companyName.setOpaque(true);
+	        add(companyName);
+		  
+		  	jtbSettings = new JButton("Settings");
+		  	jtbSettings.setBackground(Color.WHITE);
+		  	jtbSettings.setHorizontalAlignment(SwingConstants.CENTER);
+	        jtbSettings.setOpaque(true);
+	        jtbSettings.setActionCommand("SettingsMenu");
+	        jtbSettings.setBounds(1190, 12, 70, 50);
+	        add(jtbSettings);
 	        
 		  btnTraining = new JButton("Training"); 
 		  btnTraining.setBackground(Color.WHITE);
@@ -117,16 +127,6 @@ public class TrainingSessionPoeplePane extends JPanel {
 	        btnStatistics.setActionCommand("StatisticsMenu");
 	        btnStatistics.setBounds(912, 0, 264, 75);
 	        add(btnStatistics);
-	        
-	        JLabel lblNewLabel = new JLabel("logo");
-	        lblNewLabel.setBounds(0, 0, 133, 75);
-	        lblNewLabel.setOpaque(true);
-	        add(lblNewLabel);
-	        
-	        JLabel lblNewLabel_1 = new JLabel("Profiel");
-	        lblNewLabel_1.setBounds(1186, 0, 85, 75);
-	        lblNewLabel_1.setOpaque(true);
-	        add(lblNewLabel_1);
 		
 		btnBack = new JButton("Back");
 		btnBack.setBounds(30, 100, 110, 50);
@@ -257,6 +257,7 @@ public class TrainingSessionPoeplePane extends JPanel {
 		btnEnlistedPeople.addActionListener(listener);
 		btnBooks.addActionListener(listener);
 		btnMaps.addActionListener(listener);
+		jtbSettings.addActionListener(listener);
     }
 	
 	public void setListEmployee(int id) {

--- a/src/main/java/models/Settings.java
+++ b/src/main/java/models/Settings.java
@@ -1,0 +1,84 @@
+package models;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import dataAccess.SettingsAccess;
+import dataAccess.Cache;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Settings {
+	private int companyId;
+	private String companyName;
+
+	public Settings() {
+		super();
+	}
+
+	public Settings(Settings settings) {
+		this(settings.companyId, settings.companyName);
+	}
+
+	public Settings(int companyId, String companyName) {
+		super();
+		this.companyId = companyId;
+		this.companyName = companyName;
+	}
+
+	public void save() throws URISyntaxException, IOException {
+			SettingsAccess.update(this);
+			Cache.settingsCache.put(1, this);
+	}
+
+	public void delete() throws URISyntaxException, IOException {
+			Cache.addressCache.invalidate(1);
+		
+	}
+	
+	public String getCompanyName() {
+		return companyName;
+	}
+
+	public void setCompanyName(String companyName) {
+		this.companyName = companyName;
+	}
+
+	public int getCompanyId() {
+		return companyId;
+	}
+
+	public void setCompanyId(int companyId) {
+		this.companyId = companyId;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("Company Name: " + companyName + "\n");
+		return sb.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		Settings o = (Settings) obj;
+		return companyName == o.companyName;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(companyName);
+	}
+
+}


### PR DESCRIPTION
Added settings menu to all JPanels navs. Moved JPanels out of constructor and made them datamembers so the company name labels can be changed in 1 function call instead of all action-listener callbacks. Company name can be changed and is read/written to both cache and dataservice. Looks like I also updated all imports with shortcut.